### PR TITLE
feat(chain-executor): retry failed transactions with exponential backoff

### DIFF
--- a/src/services/chain-executor.service.ts
+++ b/src/services/chain-executor.service.ts
@@ -18,7 +18,9 @@ export class ChainExecutor {
   private static _instance: ChainExecutor;
   private queues: Map<number, Map<string, TransactionData[]>>; // chainId -> signerId -> transaction queue
   private processing: Map<number, Map<string, boolean>>; // Tracks processing status for each signer on each chain
-  private static readonly MAX_RETRIES = 3;
+  private static readonly MAX_RETRIES = 30;
+  private static readonly BASE_RETRY_DELAY_MS = 5 * 1_000;
+  private static readonly MAX_RETRY_DELAY_MS = 15 * 60 * 1_000;
 
   private constructor() {
     this.queues = new Map();
@@ -82,7 +84,14 @@ export class ChainExecutor {
       transactionData.retries = transactionData.retries ?? 0;
       if (transactionData.retries < ChainExecutor.MAX_RETRIES) {
         transactionData.retries++;
-        queue.push(transactionData);
+        const delayMs = Math.min(
+          ChainExecutor.BASE_RETRY_DELAY_MS * Math.pow(2, transactionData.retries - 1),
+          ChainExecutor.MAX_RETRY_DELAY_MS
+        );
+        setTimeout(() => {
+          this.queues.get(chainId)!.get(signerId)!.push(transactionData);
+          this.processNext(chainId, signerId);
+        }, delayMs);
       } else {
         if (transactionData.callback) {
           transactionData.callback(false, '');


### PR DESCRIPTION
 ## Summary
  - Raise `ChainExecutor` `MAX_RETRIES` to 30
  - Re-queue failed transactions after exponential backoff (5s base, 15min cap) instead of pushing them back immediately
  - Backoff sequence: 5s, 10s, 20s, 40s, 80s, 160s, 320s, 640s, then capped at 900s for the remaining retries
  - Queue keeps draining other transactions while a failed tx waits for its next attempt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced transaction execution with exponential backoff retry strategy, improving reliability during transient failures while reducing unnecessary server load during retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->