### PR TITLE
feat: add option to suppress event-notification alerts

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -4,6 +4,7 @@
     "port": "4337",
     "indexerAlert": "alert-1",
     "skipFirstAccountSetupAlert": false,
+    "suppressAlerts": false,
     "trustProxy": true,
     "sentryDSN": "...",
     "rateLimit": 50

--- a/src/config/config-manager.ts
+++ b/src/config/config-manager.ts
@@ -18,6 +18,7 @@ type Config = {
     port: number | string;
     indexerAlert: string;
     skipFirstAccountSetupAlert?: boolean;
+    suppressAlerts?: boolean | string;
     sentryDSN?: string;
     trustProxy: boolean | string;
     rateLimit: number | string;
@@ -79,6 +80,7 @@ export class Configuration {
   public trustProxy!: boolean;
   public rateLimit!: number;
   public skipFirstAccountSetupAlert!: boolean;
+  public suppressAlerts!: boolean;
   private readonly config: Config;
   private static _instance?: Configuration;
 
@@ -156,6 +158,10 @@ export class Configuration {
     this.port = port;
     this.indexerAlert = options.indexerAlert;
     this.skipFirstAccountSetupAlert = options.skipFirstAccountSetupAlert ?? false;
+    this.suppressAlerts = (options.suppressAlerts ?? false).toString().toLowerCase() === "true";
+    if (this.suppressAlerts) {
+      console.warn("[safe-recovery-service] options.suppressAlerts=true — event-notification alerts will not be delivered (OTPs unaffected).");
+    }
     this.trustProxy = (options.trustProxy ?? "true").toString().toLowerCase() === "true";
     this.rateLimit = rateLimit;
   }

--- a/src/services/alerts.service.ts
+++ b/src/services/alerts.service.ts
@@ -207,6 +207,15 @@ async function _sendNotification(target: string, notifications: AlertSubscriptio
     });
     return;
   }
+  if (Configuration.instance().suppressAlerts) {
+    for (const notification of notifications) {
+      await prisma.alertSubscriptionNotification.update({
+        data: {deliveryStatus: "SENT"},
+        where: {id: notification.id}
+      });
+    }
+    return;
+  }
   let messages:SummaryMessageData[] = [];
   for (const notification of notifications){
       messages.push(


### PR DESCRIPTION
## Summary
  - New `options.suppressAlerts` boolean in `config.json` (default `false`, supports `ENV::SUPPRESS_ALERTS`).
  - When enabled, batched event notifications in `alerts.service._sendNotification` are marked `SENT` without contacting
   SMTP/Twilio/webhook.
  - Channel-misconfig still surfaces as `FAILED`; OTP sends (`/auth` registration & signature requests, `/alerts`
  subscription activation) are intentionally not suppressed so user-facing flows keep working.

  ## Motivation
  Operators running staging/CI/local environments need a way to silence outbound delivery without stripping channel
  credentials from `config.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `suppressAlerts` configuration option to control delivery of event-notification alerts, disabled by default.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/safe-recovery-service/pull/15)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->