### PR TITLE
fix(siwe): always enforce issuedAt 5m max-age

### DIFF
--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -188,6 +188,16 @@ export function verifySiweMessageData(message: SiweMessage, account: string, cha
     return [false, `issuedAt could not be parsed in signed message, please make sure it is correctly formatted`];
   }
   const currentTimestamp = Date.now();
+  const siweMaxAgeMs = 60 * 5 * 1000;
+  // Reject far-future issuedAt (small clock skew allowed).
+  if (messageTimestamp > currentTimestamp + 30_000) {
+    return [false, `issuedAt is in the future`];
+  }
+  // Always enforce issuedAt freshness. Previously skipped when expirationTime was
+  // set, so a SIWE with years-long Expiration Time stayed valid for recovery auth.
+  if ((currentTimestamp - messageTimestamp) > siweMaxAgeMs) {
+    return [false, `issuedAt is valid only for 5 minutes and signature is already expired`];
+  }
   if (message.notBefore){
     const notBeforeTimestamp = Date.parse(message.notBefore);
     if (Number.isNaN(notBeforeTimestamp)){
@@ -205,9 +215,8 @@ export function verifySiweMessageData(message: SiweMessage, account: string, cha
     if (expirationTimestamp < currentTimestamp) {
       return [false, `expirationTimestamp has passed and signature has expired`];
     }
-  }else{
-    if ((currentTimestamp - messageTimestamp) > (60*5*1000)) {
-      return [false, `issuedAt is valid only for 5 minutes and signature is already expired`];
+    if ((expirationTimestamp - messageTimestamp) > siweMaxAgeMs) {
+      return [false, `expirationTime exceeds the 5 minute maximum lifetime`];
     }
   }
   nonceTracker.add(messageIdentifier);

--- a/test/siwe-issuedat-max-age.test.ts
+++ b/test/siwe-issuedat-max-age.test.ts
@@ -1,0 +1,64 @@
+import { SiweMessage } from 'siwe';
+import { verifySiweMessageData } from '../src/utils/utilities';
+
+const account = '0x1111111111111111111111111111111111111111';
+const chainId = 1;
+const statement = 'register';
+
+function buildMessage(args: {
+  issuedAt: string;
+  expirationTime?: string;
+}): SiweMessage {
+  return new SiweMessage({
+    domain: 'localhost',
+    address: account,
+    statement,
+    uri: 'https://localhost',
+    version: '1',
+    chainId,
+    nonce: Math.random().toString(36).slice(2),
+    issuedAt: args.issuedAt,
+    expirationTime: args.expirationTime,
+  });
+}
+
+describe('verifySiweMessageData issuedAt freshness', () => {
+  it('rejects stale issuedAt even when expirationTime is far in the future', () => {
+    const issuedAt = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    const expirationTime = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString();
+    const [ok, err] = verifySiweMessageData(
+      buildMessage({ issuedAt, expirationTime }),
+      account,
+      chainId,
+      statement,
+    );
+    expect(ok).toBe(false);
+    expect(err).toMatch(/issuedAt is valid only for 5 minutes/);
+  });
+
+  it('rejects expirationTime lifetime longer than 5 minutes', () => {
+    const issuedAt = new Date().toISOString();
+    const expirationTime = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const [ok, err] = verifySiweMessageData(
+      buildMessage({ issuedAt, expirationTime }),
+      account,
+      chainId,
+      statement,
+    );
+    expect(ok).toBe(false);
+    expect(err).toMatch(/expirationTime exceeds the 5 minute maximum lifetime/);
+  });
+
+  it('accepts fresh issuedAt with short expirationTime', () => {
+    const issuedAt = new Date().toISOString();
+    const expirationTime = new Date(Date.now() + 2 * 60 * 1000).toISOString();
+    const [ok, err] = verifySiweMessageData(
+      buildMessage({ issuedAt, expirationTime }),
+      account,
+      chainId,
+      statement,
+    );
+    expect(err).toBe('');
+    expect(ok).toBe(true);
+  });
+});

--- a/test/siwe-issuedat-max-age.test.ts
+++ b/test/siwe-issuedat-max-age.test.ts
@@ -23,6 +23,18 @@ function buildMessage(args: {
 }
 
 describe('verifySiweMessageData issuedAt freshness', () => {
+  it('rejects issuedAt more than 30 seconds in the future', () => {
+    const issuedAt = new Date(Date.now() + 60 * 1000).toISOString();
+    const [ok, err] = verifySiweMessageData(
+      buildMessage({ issuedAt }),
+      account,
+      chainId,
+      statement,
+    );
+    expect(ok).toBe(false);
+    expect(err).toMatch(/issuedAt is in the future/);
+  });
+
   it('rejects stale issuedAt even when expirationTime is far in the future', () => {
     const issuedAt = new Date(Date.now() - 10 * 60 * 1000).toISOString();
     const expirationTime = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString();


### PR DESCRIPTION
## Summary
- `verifySiweMessageData` skipped the 5-minute `issuedAt` freshness check whenever `expirationTime` was present.
- A SIWE with a far-future `Expiration Time` therefore remained valid for guardian register/fetch/delete and alert subscribe/unsubscribe until that expiry (in-memory nonce does not survive restart).
- Always enforce the 5-minute `issuedAt` window, reject far-future `issuedAt`, and cap `expirationTime - issuedAt` to the same bound.

## Test plan
- [x] `npx jest test/siwe-issuedat-max-age.test.ts --runInBand` → 3/3
- [ ] CI green on this PR

Tooling assist used for prep; commit authored/signed by me (no Cursor co-author trailer).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in message validation by rejecting timestamps set too far in the future or older than five minutes.
  * Enforced a maximum five-minute lifetime for messages with an expiration time.

* **Tests**
  * Added coverage for stale, future-dated, overly long, and valid sign-in message timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->